### PR TITLE
 Add extra tests for 0 and fix empty string error

### DIFF
--- a/src/Luhn/Algorithm/LuhnAlgorithm.php
+++ b/src/Luhn/Algorithm/LuhnAlgorithm.php
@@ -2,6 +2,7 @@
 
 namespace MarvinLabs\Luhn\Algorithm;
 
+use InvalidArgumentException;
 use MarvinLabs\Luhn\Contracts\LuhnAlgorithm as LuhnAlgorithmContract;
 
 /**
@@ -12,7 +13,11 @@ class LuhnAlgorithm implements LuhnAlgorithmContract
 
     public function isValid(string $input): bool
     {
-        [$number, $lastDigit] = $this->cleanAndSplitInput($input);
+        try {
+            [$number, $lastDigit] = $this->cleanAndSplitInput($input);
+        } catch (InvalidArgumentException $e) {
+            return false;
+        }
 
         $checksum = $this->computeCheckSum($number);
         $sum = $checksum + $lastDigit;
@@ -59,6 +64,11 @@ class LuhnAlgorithm implements LuhnAlgorithmContract
         // Remove everything not a digit, then extract check digit
         $input = \preg_replace('/\D/', '', $input);
         $inputLength = \strlen($input);
+
+        if ($inputLength === 0) {
+            throw new InvalidArgumentException;
+        }
+
         return [
             \substr($input, 0, $inputLength - 1),
             (int)$input[$inputLength - 1],

--- a/tests/AlgorithmTest.php
+++ b/tests/AlgorithmTest.php
@@ -21,11 +21,13 @@ class AlgorithmTest extends TestCase
     {
         return [
             'default'        => ['837668185', true],
+            'zero'           => ['0', true],
             'with_spaces'    => ['837 668  185', true],
             '123455'         => ['123455', true],
             '4103219202'     => ['4103219202', true],
             '31997233700020' => ['31997233700020', true],
             'large'          => ['89148000003974165685', true],
+            'empty'          => ['', false],
             'invalid'        => ['123456789', false],
             '123'            => ['123', false],
         ];


### PR DESCRIPTION
Passing an empty string creates an error - now it returns `false`.

---

Also add an extra tests for `0` which is valid.