### PR TITLE
Support Laravel 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   ],
   "require": {
     "php": ">=7.1",
-    "illuminate/support": "^5.5|^6.0|^7.0"
+    "illuminate/support": "^5.5|^6.0|^7.0|^8.0"
   },
   "require-dev": {
     "roave/security-advisories": "dev-master",


### PR DESCRIPTION
Laravel 8 is now released (https://github.com/laravel/framework/releases).

This PR change the `illuminate/support` requirement to accept up to version 8.0